### PR TITLE
Add missing `pygeos` dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,6 +13,7 @@ numpy>=1.21.4
 odc_ui>=0.2.0a2
 pyTMD>=1.0.6
 pandas>=1.3.4
+pygeos>=0.10.2
 pyproj>=3.2.1
 pytz>=2021.1
 PyYAML>=6.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ REQUIRED = [
     "numpy",
     "odc_ui",
     "pandas",
+    "pygeos",
     "pyproj",
     "pyTMD",
     "pytz",


### PR DESCRIPTION
Argo test failed with error:
```
ERROR Study area 69: Failed to run process with error Currently, only PyGEOS >= 0.10.0 supports `nearest_all`. To use PyGEOS within GeoPandas, you need to install PyGEOS: 'conda install pygeos' or 'pip install pygeos'
```

This PR adds `pygeos` to `requirements.in` and `setup.py` to attempt to fix this.