### PR TITLE
Fix two bugs with processing of new spatial datasets

### DIFF
--- a/coastlines/vector.py
+++ b/coastlines/vector.py
@@ -1211,9 +1211,9 @@ def rocky_shoreline_flag(
         max_distance=300,
     )
 
-    # Return boolean indicating whether point was rocky; take max of 
+    # Return boolean indicating whether point was rocky; take max of
     # each unique index value (i.e. True if there are both True and False)
-    # to account for edge case where nearest geomorphology is the corner 
+    # to account for edge case where nearest geomorphology is the corner
     # of two vector features
     return (joined["rocky"] == True).groupby(joined.index).max()
 
@@ -1263,8 +1263,19 @@ def region_atttributes(gdf, region_gdf, attribute_col="TERRITORY1", rename_col=F
             dict(zip(attribute_col, rename_col)), axis=1
         )
 
-    # Spatial join region data to points and select only required fields
-    joined_df = gdf.sjoin(region_subset, how="left").drop("index_right", axis=1)
+    # Spatial join region data to points
+    if gdf.iloc[0].geometry.type == "Point":
+        joined_df = gdf.sjoin(region_subset, how="left").drop("index_right", axis=1)
+
+    # Or if data is not points, use overlay (overlay removes index on
+    # gdf1, so we need to reset to keep it as a columnm, then reapply)
+    else:
+        joined_df = gpd.overlay(
+            gdf.reset_index(),
+            region_subset,
+            how="union",
+            keep_geom_type=True,
+        ).set_index(gdf.index.name)
 
     return joined_df
 
@@ -1401,7 +1412,7 @@ def generate_vectors(
             yearly_ds,
             str(baseline_year),
             water_index,
-            max_valid_dist=3000,
+            max_valid_dist=5000,
         )
         log.info(
             f"Study area {study_area}: Calculated distances to each annual shoreline"

--- a/coastlines/vector.py
+++ b/coastlines/vector.py
@@ -1209,10 +1209,13 @@ def rocky_shoreline_flag(
         geomorphology_gdf[["rocky", "geometry"]],
         how="left",
         max_distance=300,
-    )["rocky"]
+    )
 
-    # Return boolean indicating whether point was rocky
-    return joined == True
+    # Return boolean indicating whether point was rocky; take max of 
+    # each unique index value (i.e. True if there are both True and False)
+    # to account for edge case where nearest geomorphology is the corner 
+    # of two vector features
+    return (joined["rocky"] == True).groupby(joined.index).max()
 
 
 def region_atttributes(gdf, region_gdf, attribute_col="TERRITORY1", rename_col=False):

--- a/notebooks/DEAfricaCoastlines_generation_CLI.ipynb
+++ b/notebooks/DEAfricaCoastlines_generation_CLI.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "config_path = 'configs/deafrica_coastlines_config.yaml'\n",
-    "study_area = 1694\n",
+    "study_area = 168\n",
     "raster_version = 'cli_update'\n",
     "vector_version = 'cli_update'\n",
     "continental_version = 'cli_update'"
@@ -111,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m coastlines.raster --config_path {config_path} --study_area {study_area} --raster_version {raster_version} --start_year 1998 --end_year 2021"
+    "!python -m coastlines.raster --config_path {config_path} --study_area {study_area} --raster_version {raster_version} --start_year 2000 --end_year 2020"
    ]
   },
   {
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m coastlines.vector --config_path {config_path} --study_area {study_area} --raster_version {raster_version} --vector_version {vector_version} --baseline_year 2020"
+    "!python -m coastlines.vector --config_path {config_path} --study_area {study_area} --raster_version {raster_version} --vector_version {vector_version} --start_year 2000 --end_year 2020 --baseline_year 2020"
    ]
   },
   {
@@ -193,23 +193,6 @@
    "source": [
     "## Example combined analysis\n",
     "This demonstrates how the three components of DE Africa Coastlines (raster generation, vector generation and continental layers generation) can be applied automatically to a sequence of input study area grid cells."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8c9c1ee3-cc82-4935-862c-9d782e7b605a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import glob\n",
-    "\n",
-    "# Study areas\n",
-    "study_areas = [\n",
-    "    int(os.path.basename(i).replace(raster_version, \"\").replace(\"_\", \"\"))\n",
-    "    for i in glob.glob(f\"data/interim/raster/{raster_version}/*\")\n",
-    "]"
    ]
   },
   {

--- a/notebooks/DEAfricaCoastlines_generation_vector.ipynb
+++ b/notebooks/DEAfricaCoastlines_generation_vector.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "study_area = 636\n",
+    "study_area = 168\n",
     "raster_version = \"cli_update\"\n",
     "vector_version = \"cli_update\"\n",
     "water_index = \"mndwi\"\n",
@@ -279,7 +279,7 @@
     "        yearly_ds,\n",
     "        str(baseline_year),\n",
     "        water_index,\n",
-    "        max_valid_dist=3000,\n",
+    "        max_valid_dist=5000,\n",
     "    )"
    ]
   },


### PR DESCRIPTION
Bug one:
- If a rate of change point was "nearest" the corner of two geomorphology vector line features, GeoPanda's spatial join would include both results as rows in the joined dataframe. This produced different numbers of rows in the "rocky shoreline" data and the original rate of change points data, preventing them from being combined. Solution: group by index value to combine multiple rows with the same index into one.

Bug two:
- Applying spatial join to annual shoreline line features created duplicates of each intersecting line, rather than splitting the lines at polygon boundaries. Solution: use spatial overlay instead which breaks likes at their polygon boundaries.