### PR TITLE
Fix bug with incorrect p-value threshold used to identify significant rates of change

### DIFF
--- a/coastlines/continental.py
+++ b/coastlines/continental.py
@@ -48,7 +48,7 @@ def wms_fields(gdf):
             wms_conf=gdf.se_time * 1.96,
             wms_grew=gdf.rate_time < 0,
             wms_retr=gdf.rate_time > 0,
-            wms_sig=gdf.sig_time <= 0,
+            wms_sig=gdf.sig_time <= 0.01,
             wms_good=gdf.certainty == "good",
         )
     )


### PR DESCRIPTION
This bug causes points with significant rates of change greater than 0 but less than 0.01 to show as non-significant when clicked on in DE Africa maps. The fix is to change the incorrect "0" threshold to the correct "0.01" threshold.