### PR TITLE
change STAC item url

### DIFF
--- a/metadata/coastlines_stac_collection.json
+++ b/metadata/coastlines_stac_collection.json
@@ -30,7 +30,7 @@
     "links": [
         {
             "rel": "items",
-            "href": "https://raw.githubusercontent.com/Indiphile/coastline_stac_metadata/master/coastlines_stac_item.json"
+            "href": "https://raw.githubusercontent.com/digitalearthafrica/deafrica-coastlines/main/metadata/coastlines_stac_item.json"
         },
         {
             "rel": "root",


### PR DESCRIPTION
Changing STAC  item URL from TEST repo[](https://raw.githubusercontent.com/Indiphile/coastline_stac_metadata/master/coastlines_stac_item.json) to [DE Africa-coastlines repo](https://raw.githubusercontent.com/digitalearthafrica/deafrica-coastlines/main/metadata/coastlines_stac_item.json).